### PR TITLE
fixing compiler errors in module.go

### DIFF
--- a/router/module.go
+++ b/router/module.go
@@ -255,7 +255,7 @@ func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 
 			amount, ok := sdk.NewIntFromString(newData.Amount)
 			if !ok {
-				return channeltypes.NewErrorAcknowledgement("failed to construct int from fungile token packet data amount")
+				return channeltypes.NewErrorAcknowledgement("failed to construct int from fungible token packet data amount")
 			}
 
 			var token = sdk.NewCoin(denom, amount)

--- a/router/module.go
+++ b/router/module.go
@@ -252,7 +252,13 @@ func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 				prefixedDenom := transfertypes.GetDenomPrefix(packet.GetDestPort(), packet.GetDestChannel()) + newData.Denom
 				denom = transfertypes.ParseDenomTrace(prefixedDenom).IBCDenom()
 			}
-			var token = sdk.NewCoin(denom, sdk.NewIntFromUint64(newData.Amount))
+
+			amount, ok := sdk.NewIntFromString(newData.Amount)
+			if !ok {
+				return channeltypes.NewErrorAcknowledgement("failed to construct int from fungile token packet data amount")
+			}
+
+			var token = sdk.NewCoin(denom, amount)
 			if err := am.keeper.ForwardTransferPacket(ctx, receiver, token, port, channel, finalDest, []metrics.Label{}); err != nil {
 				ack = channeltypes.NewErrorAcknowledgement("failed to foward transfer packet")
 			}
@@ -262,13 +268,25 @@ func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface
-func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte, relayer sdk.AccAddress) (*sdk.Result, error) {
+func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte, relayer sdk.AccAddress) error {
 	return am.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 }
 
 // OnTimeoutPacket implements the IBCModule interface
-func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) (*sdk.Result, error) {
+func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) error {
 	return am.app.OnTimeoutPacket(ctx, packet, relayer)
+}
+
+// NegotiateAppVersion implements the IBCModue interface
+func (am AppModule) NegotiateAppVersion(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionID string,
+	portID string,
+	counterparty channeltypes.Counterparty,
+	proposedVersion string,
+) (string, error) {
+	return am.app.NegotiateAppVersion(ctx, order, connectionID, portID, counterparty, proposedVersion)
 }
 
 // For now this assumes one hop, should be better parsing


### PR DESCRIPTION
I've fixed up the compiler errors in `module.go` with a pretty quick gloss over. I just tried to give a relatively reasonable error message for the parsing of int64 -> string for the `FungibleTokenPacketData` update (I believe the `amount` field is now a string).

I also did not add the `third_party/proto` dependencies I mentioned via slack dms - as there was just more errors about proto dependencies when I tried to run `make proto-all`. But it's worth noting perhaps in the PR to the upstream repo that we maintain `third_party/proto` in ibc-go and that seems to be missing here.